### PR TITLE
CASMPET-4633 : BREAK/FIX - Investigate CPU Throttling alerts on various sonar-jobs-watcher pods

### DIFF
--- a/kubernetes/cray-drydock/templates/sonar-jobs-watcher.yaml
+++ b/kubernetes/cray-drydock/templates/sonar-jobs-watcher.yaml
@@ -35,13 +35,12 @@ spec:
         {{- range .Values.sonar.jobsWatcher.namespaces }}
         - {{ . | quote }}
         {{- end }}
+        {{- if .Values.sonar.jobsWatcher.resources }}
+        {{- with .Values.sonar.jobsWatcher.resources }}
         resources:
-          requests:
-            memory: "160Mi"
-            cpu: "500m"
-          limits:
-            memory: "320Mi"
-            cpu: "1500m"
+          {{- toYaml . | nindent 10 }}
+        {{- end -}}
+        {{- end }}
         volumeMounts:
           - name: sonar-scripts
             mountPath: /bin/sonar-jobs-watcher.sh

--- a/kubernetes/cray-drydock/values.yaml
+++ b/kubernetes/cray-drydock/values.yaml
@@ -13,6 +13,13 @@ sonar:
     image:
       repository: cray/cray-sonar
       # tag: latest
+    resources:
+      requests:
+        memory: "160Mi"
+        cpu: "500m"
+      limits:
+        memory: "320Mi"
+        cpu: "8"
     namespaces:
     - services
     - nexus


### PR DESCRIPTION
## Summary and Scope
o Fix CPU Throttling alerts on sonar-jobs-watcher pods (daemonset).
o Move the resources to values.yaml so that they can be customized post install if needed.
o For vshasta a resources.limits.cpu of 3 was sufficient but on ego 6 was needed to keep from alerting, set to 8 to give some additional headroom.
DOES THIS CHANGE INVOLVE ANY SCHEME CHANGES? N

## Issues and Related PRs
Resolves CASMPET-4633
## Testing
Tested on:

Virtual Shasta & Ego
Were the install/upgrade based validation checks/tests run?(goss tests/install-validation doc)
Was a fresh Install tested? Y/N If not, Why? Y
Was an Upgrade tested? Y/N If not, Why? Y
Was a Downgrade tested? Y/N. If not, Why? Y
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? N/A

WHAT WAS THE EXTENT OF TESTING PERFORMED? Manual
HOW WERE CHANGES VERIFIED TO BE SUCCESSFUL? Verified thru prometheus that the alerts stopped firing and thru grafana that the pods were no longer being throttled.

o Verify the daemonset is running, the resources are set as expected and the logs look good.
```
$ kubectl get pods -A | grep sonar-jobs
services            sonar-jobs-watcher-72q9j                                          1/1     Running     0          53s
services            sonar-jobs-watcher-7t8wp                                          1/1     Running     0          51s
services            sonar-jobs-watcher-cwkhs                                          1/1     Running     0          55s
$ kubectl get pod sonar-jobs-watcher-7t8wp -n services -o yaml| grep resources -A 6
    resources:
      limits:
        cpu: "8"
        memory: 320Mi
      requests:
        cpu: 500m
        memory: 160Mi

$ kubectl get daemonset/sonar-jobs-watcher -n services -o yaml | grep -A 6 resources

        resources:
          limits:
            cpu: "8"
            memory: 320Mi
          requests:
            cpu: 500m
            memory: 160Mi

$ kubectl logs --prefix=true -l name=sonar-jobs-watcher -n services | grep -i error
$ kubectl logs --prefix=true -l name=sonar-jobs-watcher -n services | grep -i done
[pod/sonar-jobs-watcher-72q9j/sonar] Done checking for completed jobs. Sleeping for 1 min
[pod/sonar-jobs-watcher-72q9j/sonar] Done checking for completed jobs. Sleeping for 1 min
[pod/sonar-jobs-watcher-7t8wp/sonar] Done checking for completed jobs. Sleeping for 1 min
[pod/sonar-jobs-watcher-7t8wp/sonar] Done checking for completed jobs. Sleeping for 1 min
[pod/sonar-jobs-watcher-cwkhs/sonar] Done checking for completed jobs. Sleeping for 1 min
[pod/sonar-jobs-watcher-cwkhs/sonar] Done checking for completed jobs. Sleeping for 1 min
```

## Risks and Mitigations
IF APPLICABLE, HAS A SECURITY AUDIT (via SNYK OR OTHERWISE) BEEN RUN? N/A
ARE THERE KNOWN ISSUES WITH THESE CHANGES? No
ANY OTHER SPECIAL CONSIDERATIONS? No

INCLUDE THE FOLLOWING ITEMS THAT APPLY. LIST ADDITIONAL ITEMS AND PROVIDE MORE DETAILED INFORMATION AS APPROPRIATE.

None