### PR TITLE
CASMPET-4643 : Release cray-drydock:2.9.0 for csm-1.1

### DIFF
--- a/kubernetes/cray-drydock/Chart.yaml
+++ b/kubernetes/cray-drydock/Chart.yaml
@@ -5,4 +5,4 @@ apiVersion: v1
 description: Foundational resources and baseline building-blocks for a Cray Kubernetes cluster
 name: cray-drydock
 home: "cloud/cray-charts"
-version: 2.8.0
+version: 2.9.0


### PR DESCRIPTION
CASMPET-4643 : Release cray-drydock:2.9.0 for csm-1.1
               * Add fix for CASMPET-4633 to csm-1.1