### PR TITLE
CASMPET-5067: Clean up orphaned CFS pods

### DIFF
--- a/kubernetes/cray-drydock/files/sonar-jobs-watcher.sh
+++ b/kubernetes/cray-drydock/files/sonar-jobs-watcher.sh
@@ -16,12 +16,74 @@ function get_containers() {
     kubectl get pods $1 -n $2 -o jsonpath='{range .status.containerStatuses[*]}{.name},{.state.running.startedAt}{.state.terminated.reason},{.restartCount},{.containerID}{"\n"}{end}'
 }
 
-function get_pods() {
+function get_job_pods() {
     kubectl get pods -n $1 -o jsonpath='{range .items[?(@.metadata.ownerReferences[*].kind=="Job")]}{@.metadata.name}{"\n"}{end}' --field-selector=spec.nodeName=${MY_NODE_NAME},status.phase=Running
+}
+
+function get_cfs_pods() {
+    kubectl get pods -n $1 -l cfsession --no-headers -o custom-columns=":metadata.name" --field-selector=spec.nodeName=${MY_NODE_NAME},status.phase=Running
 }
 
 function get_pod_restartpolicy() {
     kubectl get pods $1 -n $2 -o jsonpath='{.spec.restartPolicy}'
+}
+
+function check_pods() {
+    NAMESPACE=$1
+    GET_PODS_FN=$2
+
+    for pod in `$GET_PODS_FN $NAMESPACE`; do
+        echo "Checking containers in pod ${pod}"
+        all_containers_completed="true"
+        proxy_container_id=""
+
+        for container in `get_containers $pod $NAMESPACE;`; do
+            IFS="," read name status restart containerID <<EOF
+$container
+EOF
+
+            # Job spec.template.spec.restartPolicy: Unsupported value: "Always": supported values: "OnFailure", "Never"
+            restartpolicy=`get_pod_restartpolicy $pod $NAMESPACE`
+
+            # OnFailure : if container fails to start, the container is re-started until the job backOffLimit is reached.
+            # Istio sidecar is killed only if the container Completes - kubernetes will terminate the pod if restarts fails after backOffLimit attempts.
+            if [ "$restartpolicy" == "OnFailure" ]; then
+                echo "Found pod $pod with restartPolicy '$restartpolicy' and container '$name' with status '$status' and restart '$restart'"
+                if [ "$name" != "istio-proxy" ] && [ "$status" != "Completed" ]; then
+                    echo "$name is not yet completed";
+                    all_containers_completed="false"
+                fi;
+            # Never : if container fails to start, another job pod is started until the job backOffLimit is reached.
+            # Istio sidecar is killed if the container Completes or is in Error or OOMKilled - this allows the job pod to Complete.
+            else
+                echo "Found pod $pod with restartPolicy '$restartpolicy' and container '$name' with status '$status'"
+                if [ "$name" != "istio-proxy" ] && [ "$status" != "Completed" ] && [ "$status" != "Error" ] && [ "$status" != "OOMKilled" ]; then
+                    echo "$name is not yet completed";
+                    all_containers_completed="false"
+                fi;
+            fi;
+
+            if [ "$name" == "istio-proxy" ]; then
+                proxy_container_id=${containerID#containerd://}
+            fi
+        done;
+
+      if [ "$all_containers_completed" == "true" ] && [ "$proxy_container_id" != "" ]; then
+          echo "All containers of job pod $pod has completed. Killing istio-proxy ($proxy_container_id) to allow job to complete"
+          ./crictl stop "$proxy_container_id"
+      fi;
+
+    done;
+}
+
+function check_job_pods() {
+    echo "Checking Job pods on $MY_NODE_NAME in namespace $NAMESPACE"
+    check_pods $1 get_job_pods
+}
+
+function check_orphaned_cfs_pods() {
+    echo "Checking for orphaned CFS pods on $MY_NODE_NAME"
+    check_pods services get_cfs_pods
 }
 
 NAMESPACES="$@"
@@ -30,53 +92,13 @@ while [ 1 ]; do
     unset IFS
 
     for NAMESPACE in $NAMESPACES; do
-      echo "Checking pods on $MY_NODE_NAME in namespace $NAMESPACE"
-
-      for pod in `get_pods $NAMESPACE`; do
-          echo "Checking containers in pod ${pod}"
-          all_containers_completed="true"
-          proxy_container_id=""
-
-          for container in `get_containers $pod $NAMESPACE;`; do
-              IFS="," read name status restart containerID <<EOF
-$container
-EOF
-
-              # Job spec.template.spec.restartPolicy: Unsupported value: "Always": supported values: "OnFailure", "Never"
-              restartpolicy=`get_pod_restartpolicy $pod $NAMESPACE`
-
-              # OnFailure : if container fails to start, the container is re-started until the job backOffLimit is reached.
-              # Istio sidecar is killed only if the container Completes - kubernetes will terminate the pod if restarts fails after backOffLimit attempts.
-              if [ "$restartpolicy" == "OnFailure" ]; then
-                  echo "Found pod $pod with restartPolicy '$restartpolicy' and container '$name' with status '$status' and restart '$restart'"
-                  if [ "$name" != "istio-proxy" ] && [ "$status" != "Completed" ]; then
-                      echo "$name is not yet completed";
-                      all_containers_completed="false"
-                  fi;
-              # Never : if container fails to start, another job pod is started until the job backOffLimit is reached.
-              # Istio sidecar is killed if the container Completes or is in Error or OOMKilled - this allows the job pod to Complete.
-              else
-                  echo "Found pod $pod with restartPolicy '$restartpolicy' and container '$name' with status '$status'"
-                  if [ "$name" != "istio-proxy" ] && [ "$status" != "Completed" ] && [ "$status" != "Error" ] && [ "$status" != "OOMKilled" ]; then
-                      echo "$name is not yet completed";
-                      all_containers_completed="false"
-                  fi;
-              fi;
-
-              if [ "$name" == "istio-proxy" ]; then
-                  proxy_container_id=${containerID#containerd://}
-              fi
-          done;
-
-          if [ "$all_containers_completed" == "true" ] && [ "$proxy_container_id" != "" ]; then
-              echo "All containers of job pod $pod has completed. Killing istio-proxy ($proxy_container_id) to allow job to complete"
-              ./crictl stop "$proxy_container_id"
-          fi;
-
-      done;
-
-      echo
+        check_job_pods $NAMESPACE
+        echo
     done
+
+    sleep 5
+    check_orphaned_cfs_pods
+    echo
 
     echo "Done checking for completed jobs. Sleeping for 1 min";
     sleep 60


### PR DESCRIPTION
### Summary and Scope

On a customer system we were seeing some CFS Pods not get cleaned
up. It was expected that these Pods would be cleaned up by the
sonar-jobs-watcher. The sonar-jobs-watcher wasn't cleaning up
these pods because they didn't match the query when fetching the
list of Pods to clean up because they were orphaned. The
owning Job was gone and the ownerReferences weren't there for the
Pod anymore. It's unknown why the Pods were orphaned.

The proposed workaround is to change sonar-jobs-watcher to
look for the CFS pods. These Pods have a `cfsession` label.

IS THIS A NEW FEATURE OR CRITICAL BUG FIX? bug fix

DOES THIS CHANGE INVOLVE ANY SCHEME CHANGES?  N

REMINDER: HAVE YOU INCREMENTED VERSION NUMBERS? N/A

REMINDER 2: HAVE YOU UPDATED THE COPYRIGHT PER hpe GUIDELINES: Copyright 2014-2021 Hewlett Packard Enterprise Development LP    ? N/A

### Issues and Related PRs

* Resolves CASMPET-5067
* Change will also be needed in release/csm-1.1 release/csm-1.0 release/shasta-1.4

### Testing

Tested on:

* Virtual Shasta

Were the install/upgrade based validation checks/tests run?(goss tests/install-validation doc)
Was a fresh Install tested? Y
Was an Upgrade tested?      Y
Was a Downgrade tested?     Y
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? N/A

WHAT WAS THE EXTENT OF TESTING PERFORMED? MANUAL
HOW WERE CHANGES VERIFIED TO BE SUCCESSFUL?

Tried several scenarios with different jobs to make sure it worked as expected:

-1 Create a CronJob runs every minute
-2 Create a CronJob runs every minute has an initContainer and multiple containers.
-3 Create a CronJob runs every minute that sets cfsession
-4 Create a CronJob runs every minute that sets cfsession has an initContainer and multiple containers.
-5 Create a Job that runs sets cfsession, I delete the Job with --cascade=false
-6 Create a Job that runs sets cfsession has an initContainer and multiple containers, I delete the Job with --cascade=false
-7 Create a lot of Jobs that sets cfsession
-8 Create a lot of Jobs that runs sets cfsession, I delete the Job with --cascade=false
-9 Orphan Job Pods that don't set cfsession, not cleaned up!


### Risks and Mitigations

IF APPLICABLE, HAS A SECURITY AUDIT (via SNYK OR OTHERWISE) BEEN RUN? N/A
ARE THERE KNOWN ISSUES WITH THESE CHANGES? No
ANY OTHER SPECIAL CONSIDERATIONS? None

Requires: None
