### PR TITLE
CASMPET-5077: Version bumps for 1.2 release 1

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,1 +1,8 @@
 See the CASM PET team's [contributing guide](https://connect.us.cray.com/confluence/display/CASMPET/CONTRIBUTING).
+
+## Releasing
+
+If `sonar-jobs-watcher.sh` was changed from the previous release, the
+`sonar-jobs-watcher` Pods need to be restarted to pick up the change (they're
+not restarted automatically). This is forced by changing the `SCRIPT_VERSION`
+environment variable in the DaemonSet.

--- a/kubernetes/cray-drydock/Chart.yaml
+++ b/kubernetes/cray-drydock/Chart.yaml
@@ -5,4 +5,4 @@ apiVersion: v1
 description: Foundational resources and baseline building-blocks for a Cray Kubernetes cluster
 name: cray-drydock
 home: "cloud/cray-charts"
-version: 2.9.0
+version: 2.10.0

--- a/kubernetes/cray-drydock/templates/sonar-jobs-watcher.yaml
+++ b/kubernetes/cray-drydock/templates/sonar-jobs-watcher.yaml
@@ -30,6 +30,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: SCRIPT_VERSION
+          value: "1"
         command:
         - "/bin/sonar-jobs-watcher.sh"
         {{- range .Values.sonar.jobsWatcher.namespaces }}


### PR DESCRIPTION
This release contains:

* CASMPET-4299: Add the Shasta CA to the nexus k8s namespace
* CASMPET-5067: Clean up orphaned CFS pods

This is the first release for CSM 1.2 and there are no backwards-
incompatible changes so it's an increase in the minor version.