### PR TITLE
CASMTRIAGE-2730 Add name labels to namespaces

### DIFF
--- a/kubernetes/cray-drydock/Chart.yaml
+++ b/kubernetes/cray-drydock/Chart.yaml
@@ -5,4 +5,4 @@ apiVersion: v1
 description: Foundational resources and baseline building-blocks for a Cray Kubernetes cluster
 name: cray-drydock
 home: "cloud/cray-charts"
-version: 2.10.0
+version: 2.11.0

--- a/kubernetes/cray-drydock/templates/namespaces.yaml
+++ b/kubernetes/cray-drydock/templates/namespaces.yaml
@@ -4,6 +4,7 @@ kind: Namespace
 metadata:
   name: nexus
   labels:
+    name: nexus
     istio-injection: enabled
 ---
 apiVersion: v1
@@ -11,6 +12,7 @@ kind: Namespace
 metadata:
   name: operators
   labels:
+    name: operators
     {{- include "cray-drydock.labels" . | nindent 4 }}
 ---
 apiVersion: v1
@@ -36,6 +38,7 @@ kind: Namespace
 metadata:
   name: services
   labels:
+    name: services
     {{- include "cray-drydock.labels" . | nindent 4 }}
     istio-injection: enabled
 ---
@@ -76,6 +79,7 @@ kind: Namespace
 metadata:
   name: spire
   labels:
+    name: spire
     istio-injection: enabled
 ---
 apiVersion: v1
@@ -83,6 +87,7 @@ kind: Namespace
 metadata:
   name: gatekeeper-system
   labels:
+    name: gatekeeper-system
     admission.gatekeeper.sh/ignore: no-self-managing
     control-plane: controller-manager
     gatekeeper.sh/system: "yes"
@@ -92,6 +97,7 @@ kind: Namespace
 metadata:
   name: pki-operator
   labels:
+    name: pki-operator
     istio-injection: enabled
 ---
 apiVersion: v1
@@ -116,6 +122,7 @@ kind: Namespace
 metadata:
   name: vault
   labels:
+    name: vault
     istio-injection: enabled
 ---
 apiVersion: v1


### PR DESCRIPTION
## Summary and Scope

This adds name labels to the namespaces that did not already have them. This is needed so that we can filter on namespaces properly with network policies.  The version is being bumped in this because the fix needs to be released today so it's included in the next CSM 1.2 alpha.

## Issues and Related PRs

* Partially Resolves [CASMTRIAGE-2730](https://connect.us.cray.com/jira/browse/CASMTRIAGE-2730)


## Testing


### Tested on:

  * wasp
  * Virtual Shasta

### Test description:

Verified that the labels were added on install/upgrade and removed on downgrade.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N, there are no tests for this chart that are run in Jenkins
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] License file intact
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable