### PR TITLE
CASMPET-5595 Remove istio label from kyverno

### DIFF
--- a/kubernetes/cray-drydock/Chart.yaml
+++ b/kubernetes/cray-drydock/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: cray-drydock
-version: 2.12.2
+version: 2.13.0
 description: Foundational resources and baseline building-blocks for a Cray Kubernetes
   cluster
 keywords:

--- a/kubernetes/cray-drydock/templates/namespaces.yaml
+++ b/kubernetes/cray-drydock/templates/namespaces.yaml
@@ -171,7 +171,6 @@ metadata:
   name: kyverno
   labels:
     name: kyverno
-    istio-injection: enabled
 ---
 apiVersion: v1
 kind: LimitRange


### PR DESCRIPTION
## Summary and Scope

Kyverno does not need to be in the istio mTLS mesh. The istio-injection tag should be removed.

## Issues and Related PRs


* Resolves [CASMPET-5595](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-5595)

## Testing

No testing needed for this change. This is a new namespace for CSM 1.3.

## Risks and Mitigations

None

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

