### PR TITLE
Add multi-tenancy namespaces

### DIFF
--- a/kubernetes/cray-drydock/Chart.yaml
+++ b/kubernetes/cray-drydock/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: cray-drydock
-version: 2.14.1
+version: 2.14.2
 description: Foundational resources and baseline building-blocks for a Cray Kubernetes
   cluster
 keywords:
@@ -34,4 +34,4 @@ home: https://github.com/Cray-HPE/cray-drydock
 sources:
 - https://github.com/Cray-HPE/cray-drydock
 maintainers:
-- name: bknudson-hpe
+- name: bklein

--- a/kubernetes/cray-drydock/templates/namespaces.yaml
+++ b/kubernetes/cray-drydock/templates/namespaces.yaml
@@ -192,9 +192,59 @@ spec:
 apiVersion: v1
 kind: Namespace
 metadata:
+  name: multi-tenancy
+  labels:
+    name: multi-tenancy
+    {{- include "cray-drydock.labels" . | nindent 4 }}
+---
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: cpu-mem-limit-range
+  namespace: multi-tenancy
+  labels:
+    {{- include "cray-drydock.labels" . | nindent 4 }}
+spec:
+  limits:
+  - type: Container
+    defaultRequest:
+      cpu: "10m"
+      memory: "64Mi"
+    default:
+      cpu: "2"
+      memory: "2Gi"
+---
+apiVersion: v1
+kind: Namespace
+metadata:
   name: tenants
   labels:
     name: tenants
+    {{- include "cray-drydock.labels" . | nindent 4 }}
+---
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: cpu-mem-limit-range
+  namespace: tenants
+  labels:
+    {{- include "cray-drydock.labels" . | nindent 4 }}
+spec:
+  limits:
+  - type: Container
+    defaultRequest:
+      cpu: "10m"
+      memory: "64Mi"
+    default:
+      cpu: "2"
+      memory: "2Gi"
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: tapms-operator
+  labels:
+    name: tapms-operator
     {{- include "cray-drydock.labels" . | nindent 4 }}
     istio-injection: enabled
 ---
@@ -202,7 +252,33 @@ apiVersion: v1
 kind: LimitRange
 metadata:
   name: cpu-mem-limit-range
-  namespace: tenants
+  namespace: tapms-operator
+  labels:
+    {{- include "cray-drydock.labels" . | nindent 4 }}
+spec:
+  limits:
+  - type: Container
+    defaultRequest:
+      cpu: "10m"
+      memory: "64Mi"
+    default:
+      cpu: "2"
+      memory: "2Gi"
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: slurm-operator
+  labels:
+    name: slurm-operator
+    {{- include "cray-drydock.labels" . | nindent 4 }}
+    istio-injection: enabled
+---
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: cpu-mem-limit-range
+  namespace: slurm-operator
   labels:
     {{- include "cray-drydock.labels" . | nindent 4 }}
 spec:


### PR DESCRIPTION
## Summary and Scope

Refactor namespaces controlled by hnc controller, create specific namespaces for tapms and slurm.

## Issues and Related PRs

* Resolves [CASMINST-4841](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-4841)
* Resolves [CASMINST-4843](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-4843)

## Testing

```
multi-tenancy
├── slurm-operator
├── tapms-operator
└── tenants
    ├── [s] vcluster-coke
    │   └── [s] vcluster-coke-user
    └── [s] vcluster-pepsi
        └── [s] vcluster-pepsi-user

[s] indicates subnamespaces
```

```
ncn-m001-48d9c509:/home/bklein # kubectl get secrets -n slurm-operator
NAME                  TYPE                                  DATA   AGE
default-token-vt5br   kubernetes.io/service-account-token   3      4m2s
wlm-s3-credentials    Opaque                                7      2m23s
```


### Tested on:

  * Virtual Shasta

### Test description:

Installed/uninstalled the following charts in concert:

```
   - name: cray-drydock
     version: 2.14.5
     namespace: loftsman
   - name: cray-vault
     version: 1.3.6
     namespace: vault
   - name: cray-psp
     version: 0.4.3
     namespace: services
   - name: cray-certmanager-issuers
     version: 0.6.5
     namespace: cert-manager
   - name: cray-hnc-manager
     version: 0.0.1
     namespace: hnc-system
   - name: cray-tapms-operator
     version: 0.0.1
     namespace: tapms-operator
   - name: cray-sample-subtenant-operator
     version: 0.0.1
     namespace: tenants
```

## Risks and Mitigations

Low

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
