### PR TITLE
CASMSEC-374: version bump for gatekeeper code removed

### DIFF
--- a/kubernetes/cray-drydock/Chart.yaml
+++ b/kubernetes/cray-drydock/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: cray-drydock
-version: 2.14.4
+version: 2.14.5
 description: Foundational resources and baseline building-blocks for a Cray Kubernetes
   cluster
 keywords:


### PR DESCRIPTION
Bumping up the version for jira "CASMSEC-374: Remove opa-gatekeeper for fresh installs" changes

Gatekeeper code removed in below PR.
https://github.com/Cray-HPE/cray-drydock/pull/31
