### PR TITLE
CASMPET-6455 Add DVS network policy

### DIFF
--- a/kubernetes/cray-drydock/Chart.yaml
+++ b/kubernetes/cray-drydock/Chart.yaml
@@ -24,7 +24,7 @@
 ---
 apiVersion: v2
 name: cray-drydock
-version: 2.16.0
+version: 2.16.1
 description: Foundational resources and baseline building-blocks for a Cray Kubernetes
   cluster
 keywords:

--- a/kubernetes/cray-drydock/templates/networkpolicies.yaml
+++ b/kubernetes/cray-drydock/templates/networkpolicies.yaml
@@ -1,0 +1,58 @@
+{{/*
+MIT License
+
+(C) Copyright 2023 Hewlett Packard Enterprise Development LP
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+*/}}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: deny-access-to-other-namespaces
+  namespace: dvs
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+      - namespaceSelector:
+          matchLabels:
+            name: dvs
+  egress:
+    - to:
+      - namespaceSelector:
+          matchLabels:
+            name: dvs
+    - to:
+      - namespaceSelector:
+          matchLabels:
+            name: spire
+      - podSelector:
+          matchLabels:
+            app.kubernetes.io/name: spire-jwks
+    - to:
+      - namespaceSelector:
+          matchLabels:
+            name: spire
+      - podSelector:
+          matchLabels:
+            app.kubernetes.io/name: cray-spire-jwks


### PR DESCRIPTION
## Summary and Scope

This adds a network policy to limit network access for the DVS namespace.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMPET-6455](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-6455)

## Testing

### Tested on:

  * drax

### Test description:

Validated that dvs pods could not access other namespaces and that the continued to function properly.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [ ] License file intact
- [X] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
