### PR TITLE
CASMPET-6590 Fix DVS network policy

### DIFF
--- a/kubernetes/cray-drydock/Chart.yaml
+++ b/kubernetes/cray-drydock/Chart.yaml
@@ -24,7 +24,7 @@
 ---
 apiVersion: v2
 name: cray-drydock
-version: 2.15.1
+version: 2.15.2
 description: Foundational resources and baseline building-blocks for a Cray Kubernetes
   cluster
 keywords:

--- a/kubernetes/cray-drydock/templates/networkpolicies.yaml
+++ b/kubernetes/cray-drydock/templates/networkpolicies.yaml
@@ -36,23 +36,26 @@ spec:
     - from:
       - namespaceSelector:
           matchLabels:
-            name: dvs
+            kubernetes.io/metadata.name: dvs
+      - namespaceSelector:
+          matchLabels:
+            kubernetes.io/metadata.name: istio-system
   egress:
     - to:
       - namespaceSelector:
           matchLabels:
-            name: dvs
+            kubernetes.io/metadata.name: dvs
     - to:
       - namespaceSelector:
           matchLabels:
-            name: spire
-      - podSelector:
+            kubernetes.io/metadata.name: spire
+        podSelector:
           matchLabels:
             app.kubernetes.io/name: spire-jwks
     - to:
       - namespaceSelector:
           matchLabels:
-            name: spire
-      - podSelector:
+            kubernetes.io/metadata.name: spire
+        podSelector:
           matchLabels:
             app.kubernetes.io/name: cray-spire-jwks


### PR DESCRIPTION
The previous network policy was not correctly implemented. This will allow dvs mqtt client to talk to the dvs activemq artemis server on clusters that have working NetworkPolicies.