### PR TITLE
CASMPET-7133 update docker-kubectl version to 1.24.17 and add PSP for cert-manager namespace

### DIFF
--- a/kubernetes/cray-drydock/Chart.yaml
+++ b/kubernetes/cray-drydock/Chart.yaml
@@ -24,7 +24,7 @@
 ---
 apiVersion: v2
 name: cray-drydock
-version: 2.18.3
+version: 2.18.4
 description: Foundational resources and baseline building-blocks for a Cray Kubernetes
   cluster
 keywords:

--- a/kubernetes/cray-drydock/templates/rbac.yaml
+++ b/kubernetes/cray-drydock/templates/rbac.yaml
@@ -159,3 +159,18 @@ kind: ServiceAccount
 metadata:
   namespace: argo
   name: jobs-watcher
+---
+# RoleBinding for PSP in cert-manager namespace
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: cert-manager-psp
+  namespace: cert-manager
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: privileged-psp
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: system:serviceaccounts:cert-manager

--- a/kubernetes/cray-drydock/values.yaml
+++ b/kubernetes/cray-drydock/values.yaml
@@ -28,7 +28,7 @@
 kubectl:
   image:
     repository: artifactory.algol60.net/csm-docker/stable/docker-kubectl
-    tag: 1.19.15
+    tag: 1.24.17
 
 sonar:
   jobsWatcher:


### PR DESCRIPTION
## Summary and Scope

For k8s 1.24 in CSM 1.6, the docker-kubectl container image should be updated so that it is using version 1.24.17. (CASMPET-7221)

Additionally, the cert-manager namespace will be managed by cray-drydock in CSM 1.6. This change adds a cert-manager  RoleBinding for psp so that cert-manager pods are able to run.

This change goes with the docs-csm change here: https://github.com/Cray-HPE/docs-csm/pull/5378.

## Issues and Related PRs

* Resolves [CASMPET-7133](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7133)
* Relates to [CASMPET-7221](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7221)

## Testing

### Tested on:

  * Beau (vshasta2)

### Test description:

I tested installing/upgrading this chart how it is done in prerequisites.sh and saw that cray-drydock and cray-certmanager deployed correctly. In prerequisites.sh, cray-certmanager and cray-certmanager issuers are uninstalled and the cert-manager namespace is deleted, then cray-drydock is upgraded and the certmanager charts are reinstalled. I observed that this process works correctly.
For the docker-kubectl version change, I observed that the sonar-sync pods which use that container image worked properly and could run kubectl commands.

## Risks and Mitigations

Low risk

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

