### PR TITLE
CASMPET-7246: Upgrade the sonar-sync CronJob to use the batch/v1 API

### DIFF
--- a/kubernetes/cray-drydock/Chart.yaml
+++ b/kubernetes/cray-drydock/Chart.yaml
@@ -24,7 +24,7 @@
 ---
 apiVersion: v2
 name: cray-drydock
-version: 2.18.4
+version: 2.19.4
 description: Foundational resources and baseline building-blocks for a Cray Kubernetes
   cluster
 keywords:

--- a/kubernetes/cray-drydock/Chart.yaml
+++ b/kubernetes/cray-drydock/Chart.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2020-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2020-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/kubernetes/cray-drydock/Chart.yaml
+++ b/kubernetes/cray-drydock/Chart.yaml
@@ -24,7 +24,7 @@
 ---
 apiVersion: v2
 name: cray-drydock
-version: 2.19.4
+version: 2.19.0
 description: Foundational resources and baseline building-blocks for a Cray Kubernetes
   cluster
 keywords:

--- a/kubernetes/cray-drydock/templates/sonar-sync.yaml
+++ b/kubernetes/cray-drydock/templates/sonar-sync.yaml
@@ -22,7 +22,7 @@ ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 OTHER DEALINGS IN THE SOFTWARE.
 */}}
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: sonar-sync

--- a/kubernetes/cray-drydock/templates/sonar-sync.yaml
+++ b/kubernetes/cray-drydock/templates/sonar-sync.yaml
@@ -1,7 +1,7 @@
 {{/*
 MIT License
 
-(C) Copyright 2020-2022 Hewlett Packard Enterprise Development LP
+(C) Copyright 2020-2025 Hewlett Packard Enterprise Development LP
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),


### PR DESCRIPTION
## Summary and Scope

Upgrade the Sonar sync CronJob to use the batch/v1 API, which has been available since K8s 1.21, and which is unavailable in K8s 1.25+. This is necessary for the CSM 1.7/K8s upgrade.

## Issues and Related PRs

* Resolves [CASMPET-7246](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7246)

## Testing

### Tested on:

  * `beau` (vShasta)

### Test description:

I pulled the branch-specific Helm chart locally on beau and ran the following Helm upgrade:

```
helm upgrade -n loftsman cray-drydock ./cray-drydock-2.18.4-20241205163130+552f816.tgz
```

I then verified that subsequent `sonar-sync` `CronJob`s had the correct `apiVersion` and ran successfully in `services`.

## Risks and Mitigations

Risk is low/minimal, given that the `v1/batch` API is supported on the existing CSM Kubernetes version.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

