### PR TITLE
CASMPET-7369: Parameterize sonar-sync resources

### DIFF
--- a/kubernetes/cray-drydock/Chart.yaml
+++ b/kubernetes/cray-drydock/Chart.yaml
@@ -24,7 +24,7 @@
 ---
 apiVersion: v2
 name: cray-drydock
-version: 2.19.0
+version: 2.20.0
 description: Foundational resources and baseline building-blocks for a Cray Kubernetes
   cluster
 keywords:

--- a/kubernetes/cray-drydock/templates/sonar-sync.yaml
+++ b/kubernetes/cray-drydock/templates/sonar-sync.yaml
@@ -50,13 +50,13 @@ spec:
               image: {{ .Values.kubectl.image.repository }}:{{ .Values.kubectl.image.tag }}
               imagePullPolicy: {{ .Values.kubectl.image.pullPolicy }}
               command: ["/bin/sonar-sync.sh"]
+              # We will guarantee that .Values.sonar.sync always exists in values.yaml, to avoid nesting multiple checks.
+              {{- if .Values.sonar.sync.resources }}
+              {{- with .Values.sonar.sync.resources }}
               resources:
-                requests:
-                  memory: "1Gi"
-                  cpu: "2"
-                limits:
-                  memory: "2Gi"
-                  cpu: "6"
+                {{- toYaml . | nindent 16 }}
+              {{- end }}
+              {{- end }}
               volumeMounts:
                 - name: sonar-scripts
                   mountPath: /bin/sonar-sync.sh

--- a/kubernetes/cray-drydock/values.yaml
+++ b/kubernetes/cray-drydock/values.yaml
@@ -57,3 +57,10 @@ sonar:
       day_of_month: "*"
       month: "*"
       day_of_week: "*"
+    resources:
+      requests:
+        memory: "1Gi"
+        cpu: "2"
+      limits:
+        memory: "2Gi"
+        cpu: "6"

--- a/kubernetes/cray-drydock/values.yaml
+++ b/kubernetes/cray-drydock/values.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),


### PR DESCRIPTION
## Summary and Scope

* Add resources map subkey to the .Values.sonar.sync spec, to allow customizing the sonar-sync cron job's resource requests and limits, instead of hardcoding defaults into the chart. The existing default values are moved into values.yaml

  Note: typically, one should check every map level for existence before attempting to use variables in Helm. Instead of doing that for each level of nesting here, we will just guarantee that .Values.sonar.sync will always exist in values.yaml.

* As this change is strictly additive, and maintains the current defaults, it is backwards compatible with previous chart versions.

## Issues and Related PRs

* Resolves [CASMPET-7369](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7369).
* Change will also be needed in csm@release/1.7.

## Testing

### Tested on

* Local machine

### Test description:

Run `helm template . | less`, grep for the `sonar-sync` cron job, and note the inclusion of the existing `resources` spec:

```yaml
# Source: cray-drydock/templates/sonar-sync.yaml
apiVersion: batch/v1
kind: CronJob
metadata:
  name: sonar-sync
  namespace: services
  labels:
    helm.sh/chart: cray-drydock-2.20.0
    app.kubernetes.io/managed-by: Helm
spec:
  schedule: "*/1 * * * *"
  concurrencyPolicy: Forbid
  jobTemplate:
    spec:
      template:
        metadata:
          labels:
            cronjob-name: sonar-sync
          annotations:
            sidecar.istio.io/inject: "false"
        spec:
          restartPolicy: Never
          serviceAccountName: sonar
          containers:
            - name: "sonar"
              image: artifactory.algol60.net/csm-docker/stable/docker-kubectl:1.24.17
              imagePullPolicy:
              command: ["/bin/sonar-sync.sh"]
              # We will guarantee that .Values.sonar.sync always exists in values.yaml, to avoid nesting multiple checks.
              resources:
                limits:
                  cpu: "6"
                  memory: 2Gi
                requests:
                  cpu: "2"
                  memory: 1Gi
              volumeMounts:
                - name: sonar-scripts
                  mountPath: /bin/sonar-sync.sh
                  readOnly: true
                  subPath: sonar-sync.sh
          volumes:
            - name: sonar-scripts
              configMap:
                defaultMode: 0700
                name: sonar
```

Then, remove or comment out the `resources` map, and re-run `helm template . | less`. You should see a `CronJob` resource definition that lacks a `resources` spec.

## Risks and Mitigations

Risk is low, as the new chart behavior generates the same `CronJob` definition as the previous version, it just does it via defaults in `values.yaml` instead of hardcoded into the resource definition itself.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

