### PR TITLE
CASMTRIAGE-7905 - cray-activemq-artemis-operator in CLBO on CSM 1.7

### DIFF
--- a/kubernetes/cray-drydock/Chart.yaml
+++ b/kubernetes/cray-drydock/Chart.yaml
@@ -24,7 +24,7 @@
 ---
 apiVersion: v2
 name: cray-drydock
-version: 2.20.0
+version: 2.20.1
 description: Foundational resources and baseline building-blocks for a Cray Kubernetes
   cluster
 keywords:

--- a/kubernetes/cray-drydock/templates/networkpolicies.yaml
+++ b/kubernetes/cray-drydock/templates/networkpolicies.yaml
@@ -31,7 +31,6 @@ spec:
   podSelector: {}
   policyTypes:
     - Ingress
-    - Egress
   ingress:
     - from:
       - namespaceSelector:
@@ -40,22 +39,3 @@ spec:
       - namespaceSelector:
           matchLabels:
             kubernetes.io/metadata.name: istio-system
-  egress:
-    - to:
-      - namespaceSelector:
-          matchLabels:
-            kubernetes.io/metadata.name: dvs
-    - to:
-      - namespaceSelector:
-          matchLabels:
-            kubernetes.io/metadata.name: spire
-        podSelector:
-          matchLabels:
-            app.kubernetes.io/name: spire-jwks
-    - to:
-      - namespaceSelector:
-          matchLabels:
-            kubernetes.io/metadata.name: spire
-        podSelector:
-          matchLabels:
-            app.kubernetes.io/name: cray-spire-jwks


### PR DESCRIPTION
## Summary and Scope

Network Policies didn't work that well with Weave, they work as intended on Cilium.

In the case of the DVS MQTT service, the combination of network policies resulted in the loss of access to the Kubernetes API for the `cray-activemq-artemis-operator` pod and the `cray-dvs-mqtt-ss` pods were unable to access CoreDNS and its Istio sidecar couldn't access `istiod`.

This resulted in the need to add the istio-system, kube-system, and default namespaces to the Egress rule which makes the NetworkPolicy very unwieldy.

This PR simplfies the policy by being more permissive with Egress traffic, while maintaining the existing Ingress rule restricting inbound traffic to other pods in the `dvs` and `istio-system` namespaces.

## Issues and Related PRs

* Resolves [CASMTRIAGE-7905](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-7905), [USS-4147](https://jira-pro.it.hpe.com:8443/browse/USS-4147)

## Testing

### Tested on:

  * `wasp`

### Test description:

Deployed new NetworkPolicy to system 

```yaml
apiVersion: networking.k8s.io/v1
kind: NetworkPolicy
metadata:
  name: deny-access-to-other-namespaces
  namespace: dvs
spec:
  podSelector: {}
  policyTypes:
    - Ingress
  ingress:
    - from:
      - namespaceSelector:
          matchLabels:
            kubernetes.io/metadata.name: dvs
      - namespaceSelector:
          matchLabels:
            kubernetes.io/metadata.name: istio-system
```

The pods in the `dvs` namespace are now running as expected. The operator is no longer in CLBO and the stateful set has started (1/2 is normal for the second instance).
```
ncn-m001:~ # kubectl -n dvs get pod
NAME                                                              READY   STATUS    RESTARTS   AGE
cray-activemq-artemis-operator-controller-manager-797dc79cv2ptm   2/2     Running   0          23h
cray-dvs-mqtt-ss-0                                                2/2     Running   0          23h
cray-dvs-mqtt-ss-1                                                1/2     Running   0          23h
```

## Risks and Mitigations

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

