### PR TITLE
CASMPET-7666: Wrap rbac psp rolebindings with conditional

### DIFF
--- a/kubernetes/cray-drydock/Chart.yaml
+++ b/kubernetes/cray-drydock/Chart.yaml
@@ -24,7 +24,7 @@
 ---
 apiVersion: v2
 name: cray-drydock
-version: 2.20.2
+version: 2.20.3
 description: Foundational resources and baseline building-blocks for a Cray Kubernetes
   cluster
 keywords:

--- a/kubernetes/cray-drydock/templates/rbac.yaml
+++ b/kubernetes/cray-drydock/templates/rbac.yaml
@@ -1,7 +1,7 @@
 {{/*
 MIT License
 
-(C) Copyright 2022 Hewlett Packard Enterprise Development LP
+(C) Copyright 2022, 2025 Hewlett Packard Enterprise Development LP
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),
@@ -47,6 +47,12 @@ metadata:
   namespace: services
   name: jobs-watcher
 ---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  namespace: argo
+  name: jobs-watcher
+---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -55,7 +61,7 @@ rules:
   - apiGroups: ["", "batch"]
     resources: ["jobs"]
     verbs: ["get", "list"]
-
+{{- if .Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy" }}
 ---
 # RoleBinding for PSP in loftsman namespace
 kind: RoleBinding
@@ -154,12 +160,6 @@ subjects:
     kind: Group
     name: system:serviceaccounts:argo
 ---
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  namespace: argo
-  name: jobs-watcher
----
 # RoleBinding for PSP in cert-manager namespace
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -174,3 +174,4 @@ subjects:
   - apiGroup: rbac.authorization.k8s.io
     kind: Group
     name: system:serviceaccounts:cert-manager
+{{- end }}


### PR DESCRIPTION
## Summary and Scope

CASMPET-7666: Wrap rbac psp rolebindings with conditional so only created when PodSecurityPolicy capability exists

## Issues and Related PRs

* Resolves [CASMPET-7666](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7666)

## Testing
Tested on `beau`

Cleaned out psp rolebindings with the `remove-psp.sh` script.
```
pit:~/studenym # ./remove_psp.sh
Checking if PSP has been disabled on all control plane nodes
No existing podsecuritypolices
CLUSTERROLE_NX:  cray-certmanager-cert-manager-cainjector-psp cray-certmanager-cert-manager-psp cray-certmanager-cert-manager-webhook-psp cray-externaldns-external-dns-services-psp cray-kyverno-admission-controller cray-kyverno-background-controller cray-kyverno-cleanup-admission-reports cray-kyverno-cleanup-cluster-admission-reports cray-kyverno-cleanup-controller cray-kyverno-psp cray-kyverno-reports-controller cray-spire cray-spire-agent-psp node-problem-detector-psp privileged-psp psp-cray-sysmgmt-health-kube-state-metrics psp-cray-sysmgmt-health-prometheus-node-exporter restricted-psp restricted-transition-net-raw-psp restricted-transition-psp sealed-secrets-kube-system-psp sma-vm-cluster-clusterrole spire spire-agent-psp uas-default-psp
CLUSTERROLE_ONLY_PSP:
CLUSTERROLE_MIXED_PSP:
ROLE_NX:  ceph-cephfs/cray-ceph-csi-cephfs-nodeplugin ceph-rbd/cray-ceph-csi-rbd-nodeplugin sma/sma-vm-cluster
ROLE_ONLY_PSP:
ROLE_MIXED_PSP:
CLUSTERROLEBINDING_ONLY_PSP:
CLUSTERROLEBINDING_MIXED_PSP:
CLUSTERROLEBINDING_OTHER:
error: resource(s) were provided, but no name was specified
ROLEBINDING_CLUSTER_ONLY_PSP:  services/cray-postgres-operator-psp
ROLEBINDING_CLUSTER_MIXED_PSP:
ROLEBINDING_ONLY_PSP:
ROLEBINDING_MIXED_PSP:
ROLEBINDING_OTHER:
rolebinding.rbac.authorization.k8s.io "cray-postgres-operator-psp" deleted
PSP_ONLY_SA=ServiceAccount/cray-postgres-operator/services:services

ServiceAccount/cray-postgres-operator/services:services ==> kind=ServiceAccount name=cray-postgres-operator ns=services
delete_sa(): NOP
pit:~/studenym #
```

Upgraded `cray-drydock` chart
```
pit:~/studenym/cray-drydock # helm history -n loftsman cray-drydock
REVISION	UPDATED                 	STATUS  	CHART              	APP VERSION	DESCRIPTION
1       	Mon Aug 11 15:06:14 2025	deployed	cray-drydock-2.20.2	0.2.2      	Install complete
pit:~/studenym/cray-drydock # helm upgrade -n loftsman cray-drydock cray-drydock-2.20.3-20250915215646+23c2a26.tgz
Release "cray-drydock" has been upgraded. Happy Helming!
NAME: cray-drydock
LAST DEPLOYED: Mon Sep 15 22:10:03 2025
NAMESPACE: loftsman
STATUS: deployed
REVISION: 2
TEST SUITE: None
NOTES:
Foundational resources set up for a Cray Kubernetes cluster
pit:~/studenym/cray-drydock # helm history -n loftsman cray-drydock
REVISION	UPDATED                 	STATUS    	CHART                                     	APP VERSION                 DESCRIPTION
1       	Mon Aug 11 15:06:14 2025	superseded	cray-drydock-2.20.2                       	0.2.2                       Install complete
2       	Mon Sep 15 22:10:03 2025	deployed  	cray-drydock-2.20.3-20250915215646+23c2a26	0.2.2-20250915215646_23c2a26Upgrade complete
pit:~/studenym/cray-drydock #
```

Check psp rolebindings by running `remove-psp.sh` in DRY_RUN mode
```
pit:~/studenym # ./remove_psp.sh
Checking if PSP has been disabled on all control plane nodes
No existing podsecuritypolices
CLUSTERROLE_NX:  cray-certmanager-cert-manager-cainjector-psp cray-certmanager-cert-manager-psp cray-certmanager-cert-manager-webhook-psp cray-externaldns-external-dns-services-psp cray-kyverno-admission-controller cray-kyverno-background-controller cray-kyverno-cleanup-admission-reports cray-kyverno-cleanup-cluster-admission-reports cray-kyverno-cleanup-controller cray-kyverno-psp cray-kyverno-reports-controller cray-spire cray-spire-agent-psp node-problem-detector-psp privileged-psp psp-cray-sysmgmt-health-kube-state-metrics psp-cray-sysmgmt-health-prometheus-node-exporter restricted-psp restricted-transition-net-raw-psp restricted-transition-psp sealed-secrets-kube-system-psp sma-vm-cluster-clusterrole spire spire-agent-psp uas-default-psp
CLUSTERROLE_ONLY_PSP:
CLUSTERROLE_MIXED_PSP:
ROLE_NX:  ceph-cephfs/cray-ceph-csi-cephfs-nodeplugin ceph-rbd/cray-ceph-csi-rbd-nodeplugin sma/sma-vm-cluster
ROLE_ONLY_PSP:
ROLE_MIXED_PSP:
CLUSTERROLEBINDING_ONLY_PSP:
CLUSTERROLEBINDING_MIXED_PSP:
CLUSTERROLEBINDING_OTHER:
error: resource(s) were provided, but no name was specified
ROLEBINDING_CLUSTER_ONLY_PSP:
ROLEBINDING_CLUSTER_MIXED_PSP:
ROLEBINDING_ONLY_PSP:
ROLEBINDING_MIXED_PSP:
ROLEBINDING_OTHER:
PSP_ONLY_SA=

delete_sa(): NOP
pit:~/studenym #
```

Rollback to previous `cray-drydock` chart, which should create all the psp rolebindings again
```
pit:~/studenym # helm rollback -n loftsman cray-drydock 1
Rollback was a success! Happy Helming!
pit:~/studenym # helm history -n loftsman cray-drydock
REVISION	UPDATED                 	STATUS    	CHART                                     	APP VERSION                 DESCRIPTION
1       	Mon Aug 11 15:06:14 2025	superseded	cray-drydock-2.20.2                       	0.2.2                       Install complete
2       	Mon Sep 15 22:10:03 2025	superseded	cray-drydock-2.20.3-20250915215646+23c2a26	0.2.2-20250915215646_23c2a26Upgrade complete
3       	Mon Sep 15 22:18:43 2025	deployed  	cray-drydock-2.20.2                       	0.2.2                       Rollback to 1
pit:~/studenym #
pit:~/studenym # ./remove_psp.sh
Checking if PSP has been disabled on all control plane nodes
No existing podsecuritypolices
CLUSTERROLE_NX:  cray-certmanager-cert-manager-cainjector-psp cray-certmanager-cert-manager-psp cray-certmanager-cert-manager-webhook-psp cray-externaldns-external-dns-services-psp cray-kyverno-admission-controller cray-kyverno-background-controller cray-kyverno-cleanup-admission-reports cray-kyverno-cleanup-cluster-admission-reports cray-kyverno-cleanup-controller cray-kyverno-psp cray-kyverno-reports-controller cray-spire cray-spire-agent-psp node-problem-detector-psp privileged-psp psp-cray-sysmgmt-health-kube-state-metrics psp-cray-sysmgmt-health-prometheus-node-exporter restricted-psp restricted-transition-net-raw-psp restricted-transition-psp sealed-secrets-kube-system-psp sma-vm-cluster-clusterrole spire spire-agent-psp uas-default-psp
CLUSTERROLE_ONLY_PSP:
CLUSTERROLE_MIXED_PSP:
ROLE_NX:  ceph-cephfs/cray-ceph-csi-cephfs-nodeplugin ceph-rbd/cray-ceph-csi-rbd-nodeplugin sma/sma-vm-cluster
ROLE_ONLY_PSP:
ROLE_MIXED_PSP:
CLUSTERROLEBINDING_ONLY_PSP:
CLUSTERROLEBINDING_MIXED_PSP:
CLUSTERROLEBINDING_OTHER:
error: resource(s) were provided, but no name was specified
ROLEBINDING_CLUSTER_ONLY_PSP:  argo/argo-psp cert-manager/cert-manager-psp istio-system/istio-system-psp loftsman/loftsman-psp operators/operators-psp services/cray-postgres-operator-psp services/services-default-psp services/sonar-psp
ROLEBINDING_CLUSTER_MIXED_PSP:
ROLEBINDING_ONLY_PSP:
ROLEBINDING_MIXED_PSP:
ROLEBINDING_OTHER:
rolebinding.rbac.authorization.k8s.io "argo-psp" deleted (server dry run)
rolebinding.rbac.authorization.k8s.io "cert-manager-psp" deleted (server dry run)
rolebinding.rbac.authorization.k8s.io "istio-system-psp" deleted (server dry run)
rolebinding.rbac.authorization.k8s.io "loftsman-psp" deleted (server dry run)
rolebinding.rbac.authorization.k8s.io "operators-psp" deleted (server dry run)
rolebinding.rbac.authorization.k8s.io "cray-postgres-operator-psp" deleted (server dry run)
rolebinding.rbac.authorization.k8s.io "services-default-psp" deleted (server dry run)
rolebinding.rbac.authorization.k8s.io "sonar-psp" deleted (server dry run)
PSP_ONLY_SA=Group/system:serviceaccounts:argo/:argo Group/system:serviceaccounts:cert-manager/:cert-manager Group/system:serviceaccounts:istio-system/:istio-system Group/system:serviceaccounts:loftsman/:loftsman Group/system:serviceaccounts:operators/:operators ServiceAccount/cray-postgres-operator/services:services ServiceAccount/default/services:services ServiceAccount/sonar/services:services ServiceAccount/jobs-watcher/services:services

ServiceAccount/cray-postgres-operator/services:services ==> kind=ServiceAccount name=cray-postgres-operator ns=services
ServiceAccount/default/services:services ==> kind=ServiceAccount name=default ns=services
ServiceAccount/sonar/services:services ==> kind=ServiceAccount name=sonar ns=services
ServiceAccount/jobs-watcher/services:services ==> kind=ServiceAccount name=jobs-watcher ns=services
delete_sa(): NOP
pit:~/studenym #
```

## Risks and Mitigations

Low


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

